### PR TITLE
Minor fix to the Example09 and some comments

### DIFF
--- a/Examples/Example09/Get-ChocoUpgradeNotification.ps1
+++ b/Examples/Example09/Get-ChocoUpgradeNotification.ps1
@@ -1,22 +1,29 @@
 Import-Module BurntToast
 
-if (Get-Command choco -ErrorAction SilentlyContinue) { 
-  New-BurntToastNotification "choco not available!"
-  throw "choco.exe is required to run this script!"
+# check if chocolatey is installed and the commands are executeable
+if (!(Get-Command choco -ErrorAction SilentlyContinue)) { 
+    New-BurntToastNotification -Text "choco not available!"
+    throw "choco.exe is required to run this script!"
 }
 
+# get a list of chocolatey packages that can be updated
 $pkgs = choco outdated --ignore-pinned --ignore-unfound -r
 $total = $pkgs.Count
 
-if ($total.Count -eq 0) {
-  New-BurntToastNotification "all Chocolatey packages are up-to-date!"
+if ($total -eq 0) {
+  New-BurntToastNotification -Text "All Chocolatey packages are up-to-date!"
 }
 else {
-  $pkgText = ""
-  $pkgs | % { $pkgText += "$($_ -split "\|" | Select-Object -First 1), " } 
-  if ($pkgText.Length -gt 103) {
-    $pkgText = $pkgText.Substring(0, 100)
-    $pkgText += "..."
-  }
-  New-BurntToastNotification -Text "there are $total package updates available", $pkgText
+    $pkgText = ""
+    foreach ($package in $pkgs)
+    {
+        $pkgText += "$($package -split "\|" | Select-Object -First 1), "
+    }
+    
+    # cut the list of entries after 103, else the New-BurntToastNotification will throw an MethodInvocationException
+    if ($pkgText.Length -gt 103) {
+        $pkgText = $pkgText.Substring(0, 100)
+        $pkgText += "..."
+    }
+    New-BurntToastNotification -Text "There are $total package updates available:", $pkgText
 }


### PR DESCRIPTION
Changed `foreach` to `foreach-object` - Ref.: [A speed comparison (Foreach vs. Foreach-Object)](https://sid-500.com/2017/08/31/measure-command-a-speed-comparison-foreach-vs-foreach-object/).

Added the `-Text`-Parameter to the `New-BurntToastNotification` call. (causes an error before).