### PR TITLE
(GH-125) Make Header ID optional

### DIFF
--- a/BurntToast/Public/New-BTHeader.ps1
+++ b/BurntToast/Public/New-BTHeader.ps1
@@ -16,7 +16,7 @@
         Microsoft.Toolkit.Uwp.Notifications.ToastHeader
 
         .EXAMPLE
-        New-BTHeader -Id 'primary header' -Title 'First Category'
+        New-BTHeader -Title 'First Category'
 
         This command creates a Toast Header object, which will be displayed with the text "First Category."
 
@@ -37,8 +37,8 @@
         # Unique string that identifies a header. If a new Id is provided, the system will treat the header as a new header even if it has the same display text as a previous header.
         #
         # It is possible to update a header's display text by re-using the Id but changing the title.
-        [Parameter(Mandatory)]
-        [string] $Id,
+        [Parameter()]
+        [string] $Id = 'ID' + (New-Guid).ToString().Replace('-','').ToUpper(),
 
         # The header string that is displayed to the user.
         [Parameter(Mandatory)]

--- a/Tests/New-BTHeader.Tests.ps1
+++ b/Tests/New-BTHeader.Tests.ps1
@@ -16,6 +16,23 @@ Describe 'New-BTHeader' {
             $Log | Should -Be $Expected
         }
     }
+
+    Context 'loaded without Id' {
+        Start-Transcript tmp.log
+        try {
+            New-BTHeader -Title 'First Category' -WhatIf
+        }
+        finally {
+            Stop-Transcript
+            $Log = (Get-Content tmp.log).Where({ $_ -match "What if: " })
+            Remove-Item tmp.log
+        }
+        It 'generates an Id' {
+            $Expected = 'Id=[a-zA-Z\d]+:Title'
+            $Log | Should -Match $Expected
+        }
+    }
+
     Context 'clickable header text' {
         Start-Transcript tmp.log
         try {


### PR DESCRIPTION
Fixes #125 

Previously the Id parameter to New-BTHeader was mandatory however as it can be
a generated unique string it doesn't have to be.  This commit modifies the
Id parameter so it is no longer mandatory and uses a GUID style string as the
autogenerated Id if none is passed.  GUIDs are used instead of, say, the title
because they are guaranteed to be unique whereas using the title or date/time
could cause notification Id collisions.

This commit also adds a test to ensure that the function can be called without
the -Id parameter and that it is actually generated, not left as null or an
empty string.