### PR TITLE
New Command 'New-Shortcut'

### DIFF
--- a/BurntToast/Public/New-BTAppId.ps1
+++ b/BurntToast/Public/New-BTAppId.ps1
@@ -43,7 +43,7 @@
     $RegPath = 'SOFTWARE\Microsoft\Windows\CurrentVersion\Notifications\Settings'
 
     $BaseKey =  (Get-Item HKCU:\).OpenSubKey($RegPath, $true)
-    
+
     if($PSCmdlet.ShouldProcess("creating: '$RegPath\$AppId' with property 'ShowInActionCenter' set to '1' (DWORD)")) {
         $NewKey = $BaseKey.CreateSubKey($AppId, $true)
         $NewKey.SetValue('ShowInActionCenter', 1, [Microsoft.Win32.RegistryValueKind]::DWORD)

--- a/BurntToast/Public/New-BTAppId.ps1
+++ b/BurntToast/Public/New-BTAppId.ps1
@@ -40,14 +40,12 @@
         [string] $AppId = $Script:Config.AppId
     )
 
-    $RegPath = 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Notifications\Settings'
+    $RegPath = 'SOFTWARE\Microsoft\Windows\CurrentVersion\Notifications\Settings'
 
-    if (!(Test-Path -Path "$RegPath\$AppId")) {
-        if($PSCmdlet.ShouldProcess("creating: '$RegPath\$AppId' with property 'ShowInActionCenter' set to '1' (DWORD)")) {
-            $null = New-Item -Path "$RegPath\$AppId" -Force
-            $null = New-ItemProperty -Path "$RegPath\$AppId" -Name 'ShowInActionCenter' -Value 1 -PropertyType 'DWORD'
-        }
-    } else {
-        Write-Verbose -Message 'Specified AppId is already present in the registry.'
+    $BaseKey =  (Get-Item HKCU:\).OpenSubKey($RegPath, $true)
+    
+    if($PSCmdlet.ShouldProcess("creating: '$RegPath\$AppId' with property 'ShowInActionCenter' set to '1' (DWORD)")) {
+        $NewKey = $BaseKey.CreateSubKey($AppId, $true)
+        $NewKey.SetValue('ShowInActionCenter', 1, [Microsoft.Win32.RegistryValueKind]::DWORD)
     }
 }

--- a/BurntToast/Public/New-Shortcut.ps1
+++ b/BurntToast/Public/New-Shortcut.ps1
@@ -1,0 +1,63 @@
+function New-Shortcut {
+        <#
+        .SYNOPSIS
+        Creates a new StartMenu shortcut and returns the newly created AppId.
+
+        .DESCRIPTION
+        The New-Shortcut function creates a new StartMenu shortcut and returns the newly created AppId.
+
+        .INPUTS
+        System.String
+
+        You cannot pipe input to this cmdlet.
+
+        .OUTPUTS
+        AppId
+
+        .EXAMPLE
+        New-Shortcut -AppName 'BurntToast' -ShortcutTarget 'C:\Program Files\BurntToast\BurntToast.png' -IconPath 'C:\Program Files\BurntToast\BurntToast.png'
+
+        This command creates a new shortcut to the BurntToast installer example 
+
+        .LINK
+        
+    #>
+
+    Param (
+        [ValidateNotNullOrEmpty()]
+        [String]$AppName,
+        [String]$ShortcutTarget,
+        [String]$IconPath
+    )
+
+    # Set up
+    $wshShell = New-Object -comObject WScript.Shell
+    $shortcutPath = $wshShell.SpecialFolders("StartMenu") + "\" + $AppName + ".lnk"
+
+    # Create New Shortcut
+    $newShortcut = $wshShell.CreateShortcut($shortcutPath)
+    $newShortcut.TargetPath = $ShortcutTarget
+    $newShortcut.IconLocation = $IconPath
+    $newShortcut.Description = $AppName
+    $newShortcut.WorkingDirectory =  Split-Path($ShortcutTarget)
+    $newShortcut.Save()
+
+    # Cleanup COM objects
+    Remove-COM $WshShell
+
+    # Collect AppID for the new shortcut we madeS
+    $appID = $(Get-StartApps -Name $AppName).AppID
+
+    # Forward slash is required for registry keys
+    New-BTAppId -AppId $appID.replace("\","/")
+
+    Return $appID
+}
+
+
+
+function Remove-COM ($ref) {
+    [System.Runtime.InteropServices.Marshal]::ReleaseComObject([System.__ComObject]$ref) | out-null
+    [System.GC]::Collect()
+    [System.GC]::WaitForPendingFinalizers()
+}

--- a/BurntToast/Public/New-Shortcut.ps1
+++ b/BurntToast/Public/New-Shortcut.ps1
@@ -9,6 +9,10 @@ function New-Shortcut {
         .INPUTS
         System.String
 
+        AppName = The name of the application you want seen in your toast notifications
+        ShortcutTarget = The full path that the shortcut should point to
+        IconPath = The full path of an icon to use on the shortcut
+
         You cannot pipe input to this cmdlet.
 
         .OUTPUTS
@@ -17,12 +21,12 @@ function New-Shortcut {
         .EXAMPLE
         New-Shortcut -AppName 'BurntToast' -ShortcutTarget 'C:\Program Files\BurntToast\BurntToast.png' -IconPath 'C:\Program Files\BurntToast\BurntToast.png'
 
-        This command creates a new shortcut to the BurntToast installer example 
+        This command creates a new shortcut to the BurntToast installer example
 
         .LINK
-        
-    #>
 
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
     Param (
         [ValidateNotNullOrEmpty()]
         [String]$AppName,
@@ -35,12 +39,14 @@ function New-Shortcut {
     $shortcutPath = $wshShell.SpecialFolders("StartMenu") + "\" + $AppName + ".lnk"
 
     # Create New Shortcut
-    $newShortcut = $wshShell.CreateShortcut($shortcutPath)
-    $newShortcut.TargetPath = $ShortcutTarget
-    $newShortcut.IconLocation = $IconPath
-    $newShortcut.Description = $AppName
-    $newShortcut.WorkingDirectory =  Split-Path($ShortcutTarget)
-    $newShortcut.Save()
+    if($PSCmdlet.ShouldProcess("creating start menu shortcut: '$shortcutPath' that points to target '$ShortcutTarget'")) {
+        $newShortcut = $wshShell.CreateShortcut($shortcutPath)
+        $newShortcut.TargetPath = $ShortcutTarget
+        $newShortcut.IconLocation = $IconPath
+        $newShortcut.Description = $AppName
+        $newShortcut.WorkingDirectory =  Split-Path($ShortcutTarget)
+        $newShortcut.Save()
+    }
 
     # Cleanup COM objects
     Remove-COM $WshShell
@@ -57,7 +63,9 @@ function New-Shortcut {
 
 
 function Remove-COM ($ref) {
-    [System.Runtime.InteropServices.Marshal]::ReleaseComObject([System.__ComObject]$ref) | out-null
-    [System.GC]::Collect()
-    [System.GC]::WaitForPendingFinalizers()
+    if($PSCmdlet.ShouldProcess("ReleaseComObject: '$ref' and run garbage collection")) {
+        [System.Runtime.InteropServices.Marshal]::ReleaseComObject([System.__ComObject]$ref) | out-null
+        [System.GC]::Collect()
+        [System.GC]::WaitForPendingFinalizers()
+    }
 }

--- a/BurntToast/Public/New-Shortcut.ps1
+++ b/BurntToast/Public/New-Shortcut.ps1
@@ -62,9 +62,15 @@ function New-Shortcut {
 
 
 
-function Remove-COM ($ref) {
-    if($PSCmdlet.ShouldProcess("ReleaseComObject: '$ref' and run garbage collection")) {
-        [System.Runtime.InteropServices.Marshal]::ReleaseComObject([System.__ComObject]$ref) | out-null
+function Remove-COM {
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    Param (
+        [ValidateNotNullOrEmpty()]
+        [String]$COMObject
+    )
+
+    if($PSCmdlet.ShouldProcess("ReleaseComObject: '$COMObject' and run garbage collection")) {
+        [System.Runtime.InteropServices.Marshal]::ReleaseComObject([System.__ComObject]$COMObject) | out-null
         [System.GC]::Collect()
         [System.GC]::WaitForPendingFinalizers()
     }


### PR DESCRIPTION
I wanted to display the name of my custom application in toast messages, as discussed in **#142** and #96.

After reading all the blog posts and related information I set out to create a native solution that doesn't require an installer. It should be as easy as running a command like my 'New-Shortcut'.

I found that creating a Start Menu Shortcut using `WScript.Shell` automatically makes an `AppID` equivalent to the given `TargetPath`. That works fine for me except `New-BTAppId` can't handle an `AppId` with slashes in it. So I had to update that module. I am converting backslashes to forward slashes and automatically calling `New-BTAppId` from 'New-Shortcut'.

This allows us to have a custom Shortcut with AppId using one command. The end result is that you can now call `New-BurntToastNotification -AppId ` with the target of your given shortcut and you get notifications that are "From" your app instead of from PowerShell.

This PR is a "Works on my machine" example. I tried to follow your code style. This PR will require some work to make it release quality. 