### PR TITLE
(GH-131) Add Get-BTHeader function

### DIFF
--- a/BurntToast/BurntToast.psd1
+++ b/BurntToast/BurntToast.psd1
@@ -9,7 +9,8 @@
     Copyright         = '(c) 2015 Joshua (Windos) King. All rights reserved.'
     Description       = 'Module for creating and displaying Toast Notifications on Microsoft Windows 10.'
     PowerShellVersion = '5.0'
-    FunctionsToExport = 'Get-BTHistory',
+    FunctionsToExport = 'Get-BTHeader',
+                        'Get-BTHistory',
                         'New-BTAction',
                         'New-BTAppId',
                         'New-BTAudio',

--- a/BurntToast/Private/Add-PipelineObject.ps1
+++ b/BurntToast/Private/Add-PipelineObject.ps1
@@ -1,0 +1,20 @@
+﻿# Helper function to inject arbitrary objects into a pipeline stream
+function Add-PipelineObject {
+    [cmdletBinding()]
+    param (
+        [Parameter(Mandatory,
+                   ValueFromPipeline)]
+        [Object[]] $InputObject,
+
+        [Parameter(Mandatory)]
+        [scriptblock] $Process
+    )
+
+    Process {
+        $_
+    }
+
+    End {
+        $Process.Invoke()
+    }
+}

--- a/BurntToast/Public/Get-BTHeader.ps1
+++ b/BurntToast/Public/Get-BTHeader.ps1
@@ -1,0 +1,78 @@
+function Get-BTHeader {
+    <#
+        .SYNOPSIS
+        Show all toast headers in the Action Center.
+
+        .DESCRIPTION
+        The Get-BTHeader function returns all the unique toast notification headers that are in the Action Center. Toasts that have been dismissed by the user will not be returned.
+
+        .INPUTS
+        STRING
+
+        .OUTPUTS
+        Microsoft.Toolkit.Uwp.Notifications.ToastHeader
+
+        .EXAMPLE
+        Get-BTHeader
+
+        .LINK
+        https://github.com/Windos/BurntToast/blob/main/Help/Get-BTHeader.md
+    #>
+
+    [cmdletBinding(DefaultParametersetName = 'All',
+                   HelpUri='https://github.com/Windos/BurntToast/blob/main/Help/Get-BTHeader.md')]
+    param (
+        # Specifies the AppId of the 'application' or process that spawned the toast notification.
+        [string] $AppId = $Script:Config.AppId,
+
+        # A string that uniquely identifies a toast notification to retrieve the Header for
+        [Parameter(Mandatory,
+                   ParametersetName = 'ByToastId')]
+        [Alias('ToastId')]
+        [string] $ToastUniqueIdentifier,
+
+        # The title of the Header to retrieve
+        [Parameter(Mandatory,
+                   ParametersetName = 'ByTitle')]
+        [string] $Title,
+
+        # The title of the Header to retrieve
+        [Parameter(Mandatory,
+                   ParametersetName = 'ById')]
+        [Alias('HeaderId')]
+        [string] $Id
+    )
+
+    $HistoryParams = @{
+        'AppId' = $AppId
+    }
+    if ($PSCmdlet.ParameterSetName -eq 'ByToastId') { $HistoryParams['UniqueIdentifier'] = $ToastUniqueIdentifier}
+
+    $HeaderIds = New-Object -TypeName "System.Collections.ArrayList"
+
+    # Union all of the possible Toast Notifications
+    Get-BTHistory @HistoryParams | `
+    Add-PipelineObject -Process {
+        Get-BTHistory @HistoryParams -ScheduledToast
+    } | `
+    # Only select those that actually have a valid definition
+    Where-Object { $null -ne $_.Content } | `
+    # Find unique Header nodes in the notifications
+    ForEach-Object -Process {
+        $HeaderNode = $_.Content.SelectSingleNode('//*/header')
+        if ($null -ne $HeaderNode -and $null -ne $HeaderNode.GetAttribute('id') -and $HeaderIds -notcontains $HeaderNode.GetAttribute('id')) {
+            $HeaderIds.Add($HeaderNode.GetAttribute('id')) | Out-Null
+            $HeaderNode
+        }
+    } | `
+    # Filter header by title, when specified
+    Where-Object { $PSCmdlet.ParameterSetName -ne 'ByTitle' -or $_.GetAttribute('title') -eq $Title } | `
+    # Filter header by id, when specified
+    Where-Object { $PSCmdlet.ParameterSetName -ne 'ById' -or $_.GetAttribute('id') -eq $Id } | `
+    # Convert the XML definition into an actual ToastHeader object
+    ForEach-Object -Process {
+        $Header = [Microsoft.Toolkit.Uwp.Notifications.ToastHeader]::new($HeaderNode.GetAttribute('id'), $HeaderNode.GetAttribute('title'), $HeaderNode.GetAttribute('arguments'))
+        $Header.ActivationType = $HeaderNode.GetAttribute('activationType')
+        $Header
+    }
+}

--- a/Tests/BurntToast.Tests.ps1
+++ b/Tests/BurntToast.Tests.ps1
@@ -3,7 +3,7 @@
 Describe 'BurntToast Module' {
     Context 'meta validation' {
         It 'should import functions' {
-            (Get-Module BurntToast).ExportedFunctions.Count | Should -Be 24
+            (Get-Module BurntToast).ExportedFunctions.Count | Should -Be 25
         }
 
         It 'should import aliases' {

--- a/Tests/Get-BTHeader.Tests.ps1
+++ b/Tests/Get-BTHeader.Tests.ps1
@@ -1,0 +1,118 @@
+. (Join-Path -Path $PSScriptRoot -ChildPath '_envPrep.ps1')
+
+# Helper function needs to be in the global scope so it can be used in mocks
+# Note - This may not work in Pester 5+
+Function Global:New-MockNotification(
+    $HeaderId = (New-GUID).ToString(),
+    $HeaderTitle = (New-GUID).ToString(),
+    $HeaderArguments = '',
+    $HeaderActivation = 'protocol'
+    ) {
+    $Content = @"
+<?xml version="1.0" encoding="UTF-8"?>
+<toast>
+    <visual>
+        <binding template="ToastGeneric">
+            <text>Mock Toast</text>
+        </binding>
+    </visual>
+    <actions />
+    <header id="$HeaderId" title="$HeaderTitle" arguments="$HeaderArguments" activationType="$HeaderActivation" />
+</toast>
+"@
+    $XMLContent = [Windows.Data.Xml.Dom.XmlDocument]::new()
+    $XmlContent.LoadXml($Content)
+    [Windows.UI.Notifications.ToastNotification]::new($XMLContent)
+}
+
+Describe 'Get-BTHeader' {
+    It 'should call Get-BTHistory with and without scheduled information' {
+        Mock Get-BTHistory -ModuleName BurntToast -Verifiable -ParameterFilter { $ScheduledToast }
+        Mock Get-BTHistory -ModuleName BurntToast -Verifiable -ParameterFilter { -not $ScheduledToast }
+
+        Get-BTHeader
+
+        Assert-VerifiableMock
+    }
+
+    Context 'With multiple duplicate notifications' {
+        Mock Get-BTHistory -ModuleName BurntToast -Verifiable -ParameterFilter { $ScheduledToast } {
+            New-MockNotification -HeaderId 'ID01'
+            New-MockNotification -HeaderId 'ID01'
+        }
+
+        Mock Get-BTHistory -ModuleName BurntToast -Verifiable -ParameterFilter { -not $ScheduledToast } {
+            New-MockNotification -HeaderId 'ID01'
+            New-MockNotification -HeaderId 'ID01'
+        }
+
+        It 'should ignore duplicate headers' {
+            $Headers = Get-BTHeader
+            Assert-VerifiableMock
+            $Headers.Count | Should -Be 1
+            $Headers[0].Id | Should -Be 'ID01'
+        }
+    }
+
+    Context 'With multiple unique notifications' {
+        Mock Get-BTHistory -ModuleName BurntToast -Verifiable -ParameterFilter { $ScheduledToast } {
+            New-MockNotification -HeaderId 'ID01' -HeaderTitle 'Title 01'
+            New-MockNotification -HeaderId 'ID02' -HeaderTitle 'Title 02'
+        }
+
+        Mock Get-BTHistory -ModuleName BurntToast -Verifiable -ParameterFilter { -not $ScheduledToast } {
+            New-MockNotification -HeaderId 'ID03' -HeaderTitle 'Title 03'
+            New-MockNotification -HeaderId 'ID04'
+        }
+
+        It 'should return all headers' {
+            $Headers = Get-BTHeader
+            Assert-VerifiableMock
+            $Headers.Count | Should -Be 4
+        }
+
+        It 'should return header by title' {
+            $Headers = Get-BTHeader -Title 'Title 01'
+            Assert-VerifiableMock
+            $Headers.Count | Should -Be 1
+            $Headers[0].Id | Should -Be 'ID01'
+            $Headers[0].Title | Should -Be 'Title 01'
+        }
+
+        It 'should return header by id' {
+            $Headers = Get-BTHeader -Id 'ID03'
+            Assert-VerifiableMock
+            $Headers.Count | Should -Be 1
+            $Headers[0].Id | Should -Be 'ID03'
+            $Headers[0].Title | Should -Be 'Title 03'
+        }
+
+        It 'should return no headers for a missing title' {
+            $Headers = Get-BTHeader -Title 'Title MISSING'
+            Assert-VerifiableMock
+            $Headers.Count | Should -Be 0
+        }
+
+        It 'should return no headers for a missing id' {
+            $Headers = Get-BTHeader -Id 'IDMISSING'
+            Assert-VerifiableMock
+            $Headers.Count | Should -Be 0
+        }
+    }
+
+    Context 'With a single unique notifications' {
+        Mock Get-BTHistory -ModuleName BurntToast -Verifiable -ParameterFilter { $ScheduledToast } {
+            New-MockNotification -HeaderId 'ID01' -HeaderTitle 'Title 01' -HeaderArguments 'arguments' -HeaderProtocol 'protocol'
+        }
+
+        It 'should return all header properties' {
+            $Headers = Get-BTHeader
+            Assert-VerifiableMock
+            $Headers.Count | Should -Be 1
+            $Headers.Id | Should -Be 'ID01'
+            $Headers.Title | Should -Be 'Title 01'
+            $Headers.Arguments | Should -Be 'arguments'
+            $Headers.ActivationType.ToString() | Should -Be 'Protocol'
+        }
+    }
+}


### PR DESCRIPTION
Fixes #131 

This commit adds the Get-BTHeader function which is used to query, and filter,
existing active and scheduled toasts for their unique headers. This is useful
for managing state across PowerShell scripts with toasts using the same Header.
This commit also includes tests and help text for the new function and any
private helper functions.